### PR TITLE
Fix bug in SendRaindrop component that would not allow any writes to …

### DIFF
--- a/src/components/raindrop/SendRaindrop.js
+++ b/src/components/raindrop/SendRaindrop.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Text } from 'react-native';
 import { connect } from 'react-redux';
 import Firebase from 'firebase';
 import 'firebase/firestore';
@@ -30,6 +29,7 @@ class SendRaindrop extends React.Component {
 
     const Blob = RNFetchBlob.polyfill.Blob;
     window.Blob = Blob;
+    const tempWindowXMLHttpRequest = window.XMLHttpRequest;
     window.XMLHttpRequest = RNFetchBlob.polyfill.XMLHttpRequest;
 
     const mime = 'image/jpeg';
@@ -50,12 +50,13 @@ class SendRaindrop extends React.Component {
         this.props.changeSendRaindropStatus('sent');
 
         const downloadURL = uploadTask.snapshot.downloadURL;
-        const db = Firebase.database();
-        const raindropsRef = db.ref(`users/${foundRaindropRecipient.id}/${imageUUID}`);
+
+        const db = Firebase.firestore();
+        const raindropsRef = db.collection(`users/${foundRaindropRecipient.id}/raindrops`);
 
         const senderId = user.uid;
-        const seenAt = '';
-        const createdAt = (new Date()).toString();
+        const seenAt = null;
+        const createdAt = new Date();
 
         const raindropDoc = {
           senderId,
@@ -64,7 +65,9 @@ class SendRaindrop extends React.Component {
           createdAt
         };
 
-        raindropsRef.set(raindropDoc)
+        window.XMLHttpRequest = tempWindowXMLHttpRequest;
+
+        raindropsRef.add(raindropDoc)
           .then(() => {
             // success. doing nothing OK for now.
           })


### PR DESCRIPTION
…the Firebase Cloud Firestore of the raindrop images. React-native-fetch-blob override of native window.XMLHttpRequest was breaking the Firestore write, so a temp variable was declared to be allow re-assignment of window XHR immediately prior to Cloud Firestore call. This way all data will be in Cloud Firestore still (w/o Realtime DB). If we need Realtime DB in the future, so be it, as it is battle-tested. But nice to keep all data in one 'realtime' db.